### PR TITLE
define 'iterable' = None in tg_tqdm()

### DIFF
--- a/tg_tqdm/_tg_tqdm.py
+++ b/tg_tqdm/_tg_tqdm.py
@@ -24,7 +24,7 @@ class _TelegramIO():
                 self.prev_text = self.text
 
 
-def tg_tqdm(iterable, token, chat_id, show_last_update=True,
+def tg_tqdm(token, chat_id, iterable=None, show_last_update=True,
             desc=None, total=None, leave=True, ncols=None, mininterval=1.0, maxinterval=10.0,
             miniters=None, ascii=False, disable=False, unit='it',
             unit_scale=False, dynamic_ncols=False, smoothing=0.3,
@@ -37,14 +37,15 @@ def tg_tqdm(iterable, token, chat_id, show_last_update=True,
     
         Parameters
         ----------
-        iterable  : iterable, required
-            Iterable to decorate with a progressbar.
-            Leave blank to manually manage the updates.
         token  : string, required
             Token of your telegram bot
             
         chat_id  : int, required
             Chat ID where information will be sent about the progress
+        
+        iterable  : iterable, optional
+            Iterable to decorate with a progressbar.
+            Leave blank to manually manage the updates.
             
         show_last_update  : bool, optional [default: True]
             Should I show the time-date of the last change in the progress bar?


### PR DESCRIPTION
Define parameter 'iterable' is None by default in tg_tqdm().

It is makes possible operate with tg_tqdm like as tqdm original with 'with' statement.
For example:

```
with tg_tqdm(token=example_bot_token, chat_id=example_chat_id, total=100) as t:
    while some_statement is True:
        do_someting():
        t.update()
```

It is really can be useful with some unknown action that not iterable itself of don't have length of itself.

Otherwise, it was necessary to do it like:
```
with tg_tqdm(iterable = range(1), token=example_bot_token, chat_id=example_chat_id, total=100) as t:
    while some_statement is True:
        do_someting():
        t.update()
```